### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Implement WatchKit features and I will add you to the project (I have no need an
 
 ## Installation
 
-## Using Cocoapods ##
+## Using CocoaPods ##
 [CocoaPods](https://cocoapods.org/) is a centralized dependency manager for
 Objective-C and Swift. Go [here](https://guides.cocoapods.org/using/index.html)
 to learn more.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
